### PR TITLE
Migrate from CRA to Vite + React 19

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="shortcut icon" href="/alec.jpg" />
+    <title>Alec Lorraine Music</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,20 +3,20 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "bootstrap": "^4.3.1",
-    "react": "^16.8.3",
-    "react-bootstrap": "^1.0.0-beta.5",
-    "react-cookie": "^4.0.3",
-    "react-dom": "^16.8.3",
-    "react-player": "^1.15.3",
-    "react-responsive-carousel": "^3.1.41",
-    "react-scripts": "2.1.5"
+    "bootstrap": "^5.3.3",
+    "react": "^19.1.0",
+    "react-bootstrap": "^2.10.9",
+    "react-dom": "^19.1.0",
+    "react-player": "^2.16.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.0",
+    "vite": "^6.3.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "start": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "browserslist": [
     ">0.2%",

--- a/src/App.js
+++ b/src/App.js
@@ -1,25 +1,21 @@
-import React, { Component } from 'react';
-import './App.css';
-import MusicPlayer from './MusicPlayer';
-import { Container, Row, Col, Jumbotron } from 'react-bootstrap';
-import { withCookies, Cookies } from 'react-cookie';
+import React, { Component } from "react";
+import "./App.css";
+import MusicPlayer from "./MusicPlayer";
+import { Container } from "react-bootstrap";
 
 class App extends Component {
-  componentDidMount() {
-    console.log('here;', this.props);
-  }
   render() {
     return (
       <Container fluid>
-        <Jumbotron>
+        <div className="p-5">
           <h1>Alec Lorraine Music</h1>
-          <div className="ml-3">
+          <div className="ms-3">
             <MusicPlayer />
           </div>
-        </Jumbotron>
+        </div>
       </Container>
     );
   }
 }
 
-export default withCookies(App);
+export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,13 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import { CookiesProvider } from 'react-cookie';
+import React from "react";
+import { createRoot } from "react-dom/client";
+import "bootstrap/dist/css/bootstrap.min.css";
+import "./index.css";
+import App from "./App";
 
-navigator.serviceWorker.getRegistrations().then(function(registrations) {
+navigator.serviceWorker.getRegistrations().then(function (registrations) {
   for (let registration of registrations) {
     registration.unregister();
   }
 });
 
-ReactDOM.render(
-  <CookiesProvider>
-    <App />
-  </CookiesProvider>,
-  document.getElementById('root')
-);
+createRoot(document.getElementById("root")).render(<App />);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "dist"
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react({ include: "**/*.{js,jsx}" })],
+  esbuild: {
+    loader: "jsx",
+    include: /src\/.*\.jsx?$/,
+    exclude: [],
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      loader: { ".js": "jsx" },
+    },
+  },
+});


### PR DESCRIPTION
- Replaces react-scripts 2.x with Vite 6 + @vitejs/plugin-react
- Upgrades React 16 → 19, react-bootstrap beta → 2.x (Bootstrap 5)
- Switches to createRoot API, removes unused react-cookie dependency
- Removes Jumbotron (dropped in react-bootstrap 2.x), replaces with div